### PR TITLE
Fixed bug - hid POI-load and methods-invoking to else condition

### DIFF
--- a/AugmentedSzczecin/AugmentedSzczecin/Strings/en-US/Resources.resw
+++ b/AugmentedSzczecin/AugmentedSzczecin/Strings/en-US/Resources.resw
@@ -117,8 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BothConnectionDisabledMessage" xml:space="preserve">
+    <value>Internet and Location connection disabled.</value>
+  </data>
   <data name="CurrentMapTitle.Text" xml:space="preserve">
     <value>Current Location</value>
+  </data>
+  <data name="GeolocationDisabledMessage" xml:space="preserve">
+    <value>Geolocation disabled.</value>
+  </data>
+  <data name="InternetConnectionDisabledMessage" xml:space="preserve">
+    <value>Internet Connection disabled.</value>
+  </data>
+  <data name="RefreshConnection.Label" xml:space="preserve">
+    <value>Reconnect</value>
   </data>
   <data name="ResetPasswordButtonReset.Content" xml:space="preserve">
     <value>Reset password</value>

--- a/AugmentedSzczecin/AugmentedSzczecin/ViewModels/CurrentMapViewModel.cs
+++ b/AugmentedSzczecin/AugmentedSzczecin/ViewModels/CurrentMapViewModel.cs
@@ -169,6 +169,8 @@ namespace AugmentedSzczecin.ViewModels
             }
 
             UpdateInternetConnection();
+            UpdateGeolocationEnabled();
+
             if (!InternetConnection)
             {
                 InternetConnectionDisabledMsg();
@@ -227,6 +229,19 @@ namespace AugmentedSzczecin.ViewModels
             }
 
             InternetConnection = true;
+        }
+
+        private void UpdateGeolocationEnabled()
+        {
+            var isGeolocationEnabled = _locationService.IsGeolocationEnabled();
+
+            if (!isGeolocationEnabled)
+            {
+                GeolocationEnabled = false;
+                return;
+            }
+
+            GeolocationEnabled = true;
         }
 
         public async void InternetConnectionDisabledMsg()

--- a/AugmentedSzczecin/AugmentedSzczecin/ViewModels/CurrentMapViewModel.cs
+++ b/AugmentedSzczecin/AugmentedSzczecin/ViewModels/CurrentMapViewModel.cs
@@ -67,6 +67,20 @@ namespace AugmentedSzczecin.ViewModels
             }
         }
 
+        private bool _geolocationEnabled;
+        public bool GeolocationEnabled
+        {
+            get { return _geolocationEnabled; }
+            set
+            {
+                if (value != _geolocationEnabled)
+                {
+                    _geolocationEnabled = value;
+                    NotifyOfPropertyChange(() => GeolocationEnabled);
+                }
+            }
+        }
+
         public string BingKey
         {
             get { return _bingKey; }

--- a/AugmentedSzczecin/AugmentedSzczecin/ViewModels/CurrentMapViewModel.cs
+++ b/AugmentedSzczecin/AugmentedSzczecin/ViewModels/CurrentMapViewModel.cs
@@ -39,7 +39,7 @@ namespace AugmentedSzczecin.ViewModels
         private ObservableCollection<PointOfInterest> _mapLocations;
         public ObservableCollection<PointOfInterest> MapLocations
         {
-            get 
+            get
             {
                 return _mapLocations;
             }
@@ -142,7 +142,7 @@ namespace AugmentedSzczecin.ViewModels
             base.OnActivate();
 
             CountZoomLevel();
-            
+
             HardwareButtons.BackPressed += HardwareButtons_BackPressed;
 
             if (_locationService.IsGeolocationEnabled())
@@ -159,9 +159,11 @@ namespace AugmentedSzczecin.ViewModels
             {
                 InternetConnectionDisabledMsg();
             }
-
-            _mapLocations = new ObservableCollection<PointOfInterest>();
-            RefreshPointOfInterestService();
+            else
+            {
+                _mapLocations = new ObservableCollection<PointOfInterest>();
+                RefreshPointOfInterestService();
+            }
         }
 
         protected override void OnDeactivate(bool close)

--- a/AugmentedSzczecin/AugmentedSzczecin/Views/CurrentMapView.xaml
+++ b/AugmentedSzczecin/AugmentedSzczecin/Views/CurrentMapView.xaml
@@ -69,5 +69,16 @@
         </maps:MapControl>
 
     </StackPanel>
+    
+    <Page.BottomAppBar>
+        <CommandBar
+            IsOpen="False"
+            ClosedDisplayMode="Minimal">
+            <AppBarButton
+                caliburn:Message.Attach="[Event Click] = [Action RefreshConnectionClick]"
+                x:Uid="RefreshConnection"
+                Icon="Refresh" />
+        </CommandBar>
+    </Page.BottomAppBar>
 </Page>
 


### PR DESCRIPTION
Schowałem pewne wywołania, które gryzły się z równoczesnym wyświetleniem msg.Show() od PointOfInterestEventFailed.

Teraz po prostu, kieedy nie ma połączenia z internetem, będzie wyświetlany komunikat o tym właśnie i tylko o tym (w domyśle nie załadują się Punkty POI).
Natomiast, kiedy połączenie będzie, to dopiero wtedy zajdzie potrzeba obsłużenia tego czy punkty się załadują czy nie.

Mam problem z devicem(fizycznym), dlatego też proszę, aby można było przetestować to zgodnie ze schematem jaki wrzucił tester -> https://tracker.blstreamgroup.com/jira/browse/AUGMENTEDSZN-313