### PR TITLE
Added cache-breaker parameter in login request.

### DIFF
--- a/AugmentedSzczecin/AugmentedSzczecin/Services/HttpService.cs
+++ b/AugmentedSzczecin/AugmentedSzczecin/Services/HttpService.cs
@@ -67,7 +67,7 @@ namespace AugmentedSzczecin.Services
         public async Task<int> SignIn(User user)
         {
             SetAuthenticationHeader(user.Email, user.Password);
-            var response = await _client.GetAsync("users/whoami");
+            var response = await _client.GetAsync(String.Format("users/whoami?v={0}",DateTime.Now.Ticks));
             return (int)response.StatusCode;
         }
 


### PR DESCRIPTION
Gdzieś po drodze musiał się request cache'ować. Często tak się zdarza, więc większość bibliotek dodaje specjalnie parametr do uri requestu, który służy tylko temu, żeby udawać że jest to zupełnie inny request.